### PR TITLE
Don't escape unicode when quoting strings

### DIFF
--- a/build/quote_test.go
+++ b/build/quote_test.go
@@ -40,6 +40,7 @@ var quoteTests = []struct {
 	{`"foo\\(bar"`, `foo\(bar`, true},
 	{`"""hello
 world"""`, "hello\nworld", true},
+	{`"this is fine 🤡!"`, `this is fine 🤡!`, true},
 
 	{`"\\a\\b\\f\n\r\t\\v\000\377"`, "\\a\\b\\f\n\r\t\\v\000\xFF", true},
 	{`"\\a\\b\\f\n\r\t\\v\x00\xff"`, "\\a\\b\\f\n\r\t\\v\000\xFF", false},


### PR DESCRIPTION
Buildifier escapes everything that is not Latin1 because this is what Blaze/Bazel supports(ed?) in build rules. But in configs we definitely need some unicode (yay, emoji!).